### PR TITLE
update image url to https

### DIFF
--- a/src/javascript/post_view.coffee
+++ b/src/javascript/post_view.coffee
@@ -1,6 +1,6 @@
 $ = require 'jquery'
 
-img_url = "http://i.kinja-img.com/gawker-media/image/upload/c_fill,fl_progressive,g_center,h_180,q_80,w_320"
+img_url = "https://i.kinja-img.com/gawker-media/image/upload/c_fill,fl_progressive,g_center,h_180,q_80,w_320"
 
 module.exports = PostView =
   width: $(window).width()


### PR DESCRIPTION
This fixes a 'mixed content' warning that shows when accessing the site through ssl. 

All other images are already loaded through ssl.
